### PR TITLE
Small cleanups before publishing

### DIFF
--- a/lava-api-mock/Cargo.toml
+++ b/lava-api-mock/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 authors = ["Edmund Smith <ed.smith@collabora.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
+description = "Mock crate for the LAVA REST APIs"
+homepage = "https://github.com/collabora/lava-api"
+repository = "https://github.com/collabora/lava-api"
+readme = "../README.md"
 
 [dependencies]
 boulder = { version="0.3", features = ["persian-rug"] }

--- a/lava-api/Cargo.toml
+++ b/lava-api/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 authors = ["Sjoerd Simons <sjoerd@collabora.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
+description = "Helper crate to work with the LAVA REST APIs"
+homepage = "https://github.com/collabora/lava-api"
+repository = "https://github.com/collabora/lava-api"
+readme = "../README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/lava-api/Cargo.toml
+++ b/lava-api/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lava-api"
 version = "0.1.0"
 authors = ["Sjoerd Simons <sjoerd@collabora.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Helper crate to work with the LAVA REST APIs"
 homepage = "https://github.com/collabora/lava-api"


### PR DESCRIPTION
Update the main crate to edition v2021 and adds descriptions/urls to both