### PR TITLE
Changes suggested by cargo clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: --all-targets -- -D warnings
 # Job to key the bors success status against
   bors:
     name: bors

--- a/lava-api-mock/src/devicetypes.rs
+++ b/lava-api-mock/src/devicetypes.rs
@@ -224,9 +224,9 @@ mod test {
                 .architecture(|| None)
                 .processor(|| None)
                 .cpu_model(Repeat::new([None, Some("".to_string())]))
-                .aliases(|| Vec::new())
+                .aliases(Vec::new)
                 .bits(|| None)
-                .cores(|| Vec::new())
+                .cores(Vec::new)
                 .core_count(|| None)
                 .description(Repeat::new([None, Some("".to_string())]))
                 .health_frequency(|| 10);

--- a/lava-api-mock/src/jobs.rs
+++ b/lava-api-mock/src/jobs.rs
@@ -350,9 +350,9 @@ mod tests {
                         .with_timezone(&Utc),
                     Duration::minutes(5),
                 )))
-                .tags(|| Vec::new())
-                .viewing_groups(|| Vec::new())
-                .multinode_definition(|| String::new())
+                .tags(Vec::new)
+                .viewing_groups(Vec::new)
+                .multinode_definition(String::new)
                 .health_check(Repeat!(false, true))
                 .priority(Repeat!(0, 50));
 

--- a/lava-api-mock/src/testcases.rs
+++ b/lava-api-mock/src/testcases.rs
@@ -411,7 +411,7 @@ mod tests {
 
         let ser = TestCase::get_serializer(p.access());
         for (i, tc) in tcs.iter().enumerate() {
-            let map = ser.to_row(&tc);
+            let map = ser.to_row(tc);
             let units = ["seconds".to_string(), "hours".to_string()];
             assert_eq!(map["id"], CellValue::Number(Number::from(i)));
             assert_eq!(map["name"], CellValue::String(format!("Test case {}", i)));

--- a/lava-api/examples/lava-rs/main.rs
+++ b/lava-api/examples/lava-rs/main.rs
@@ -15,7 +15,6 @@ use lava_api::joblog::JobLogError;
 use lava_api::worker::{self, Worker};
 use lava_api::Lava;
 use structopt::StructOpt;
-use tokio::io::AsyncWriteExt;
 use tokio::time::sleep;
 
 fn device_health_to_emoji(health: device::Health) -> &'static str {
@@ -82,7 +81,7 @@ async fn jobs(lava: &Lava, opts: JobsCmd) -> Result<()> {
     let mut num = opts.limit;
     while let Some(w) = jobs.try_next().await? {
         println!(" 💤️  [{}]  {}", w.id, w.description);
-        num = num - 1;
+        num -= 1;
         if num == 0 {
             match jobs.reported_items() {
                 Some(n) => println!("\n…and {} more jobs", n - 10),
@@ -102,7 +101,7 @@ async fn submit(lava: &Lava, opts: SubmitCmd) -> Result<()> {
 
     let mut ids = lava.submit_job(&definition).await?;
     println!("Submitted job(s): {:?}", ids);
-    let id = ids.pop().ok_or(anyhow!("No job id"))?;
+    let id = ids.pop().ok_or_else(|| anyhow!("No job id"))?;
     if opts.follow {
         // TODO support following more then 1 job
         let builder = lava.jobs().id(id);
@@ -163,7 +162,7 @@ struct SubmitCmd {
 #[derive(StructOpt, Debug)]
 struct LogCmd {
     #[structopt(short, long)]
-    follow: bool,
+    _follow: bool,
     job: i64,
 }
 

--- a/lava-api/src/job.rs
+++ b/lava-api/src/job.rs
@@ -724,7 +724,7 @@ mod tests {
                 job.requested_device_type.as_ref(),
                 jj.requested_device_type
                     .as_ref()
-                    .map(|t| &start.get(&t).name)
+                    .map(|t| &start.get(t).name)
             );
 
             assert_eq!(job.tags.len(), jj.tags.len());
@@ -736,7 +736,7 @@ mod tests {
 
             assert_eq!(
                 job.actual_device.as_ref(),
-                jj.actual_device.as_ref().map(|t| &start.get(&t).hostname)
+                jj.actual_device.as_ref().map(|t| &start.get(t).hostname)
             );
             assert_eq!(Some(job.submit_time), jj.submit_time);
             assert_eq!(job.start_time, jj.start_time);
@@ -800,8 +800,8 @@ mod tests {
                 base_date - Duration::minutes(1),
                 Duration::minutes(-1),
             )))
-            .start_time(GSome(Time::new(base_date.clone(), Duration::minutes(-1))))
-            .end_time(GSome(Time::new(base_date.clone(), Duration::seconds(-30))));
+            .start_time(GSome(Time::new(base_date, Duration::minutes(-1))))
+            .end_time(GSome(Time::new(base_date, Duration::seconds(-30))));
 
         let _ = GeneratorWithPersianRugMutIterator::new(&mut gen, server.state_mut())
             .take(50)

--- a/lava-api/src/test.rs
+++ b/lava-api/src/test.rs
@@ -287,10 +287,7 @@ result: fail
                 assert_eq!(job.id, start.get(&start.get(&tt.suite).job).id);
                 assert_eq!(test.start_log_line, tt.start_log_line);
                 assert_eq!(test.end_log_line, tt.end_log_line);
-                assert_eq!(
-                    test.test_set,
-                    tt.test_set.as_ref().map(|t| start.get(&t).id)
-                );
+                assert_eq!(test.test_set, tt.test_set.as_ref().map(|t| start.get(t).id));
                 assert_eq!(test.logged, tt.logged);
                 assert_eq!(test.resource_uri, tt.resource_uri);
 


### PR DESCRIPTION
The code as-is will pass `cargo clippy`, but not `cargo clippy --all-targets` to check the tests and examples as well. This contains the accumulated fixes the second command suggests.

Signed-off-by: Ed Smith <ed.smith@collabora.com>