### PR TITLE
Remove bors.toml

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,2 +1,0 @@
-status = [ "bors" ]
-delete_merged_branches = true


### PR DESCRIPTION
The repository now uses github merge queues for pull requests. Remove outdated bors.toml file

Fixes: #14

[draft as we need to setup branch protection/merge queue for the main branch first]