### PR TITLE
fix building crates standalone

### DIFF
--- a/lava-api-mock/Cargo.toml
+++ b/lava-api-mock/Cargo.toml
@@ -39,7 +39,7 @@ regex = "1.12.3"
 anyhow = "1.0.102"
 env_logger = "0.11"
 test-log = "0.2"
-reqwest = "0.13"
+reqwest = { version = "0.13", features = [ "json" ] }
 tokio-test = "0.4"
 lava-api = { path = "../lava-api" }
 junit-parser = "1"

--- a/lava-api-mock/src/lib.rs
+++ b/lava-api-mock/src/lib.rs
@@ -40,7 +40,13 @@
 //! whatever update pattern is desired.
 //!
 //! Example:
-//! ```rust
+//!
+//! Note: this example is marked `ignore` because it depends on the
+//! [`lava-api`](https://docs.rs/lava-api) client crate, which in turn
+//! depends on this crate; compiling it as a doctest would introduce a
+//! dependency cycle that breaks standalone builds of this crate.
+//!
+//! ```ignore
 //! use futures::stream::TryStreamExt;
 //! use lava_api_mock::{LavaMock, PaginationLimits, PopulationParams, SharedState};
 //! use lava_api::Lava;


### PR DESCRIPTION
The test suite calls Response::json() in several modules which reqwest gates behind its `json` feature. The dev-dependency on reqwest did not enable it.

This compiled only by accident: the tests depend on the workspace `lava-api` crate which enables reqwest/json.

When built standalone (e.g. from the published crate on crates.io) that sibling is absent; the "json" feature is not enabled, thus the tests fail to compile with:

    error[E0599]: no method named `json` found for struct `Response`

Declare the json feature explicitly in lava-api-mock's dev-dependency so the tests build regardless of workspace context.

This can be reproduced with:

    cargo package -p lava-api-mock --allow-dirty
    cd target/package/lava-api-mock-0.2.1
    cargo test